### PR TITLE
Changes made to make compatible with react 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
   "homepage": "https://github.com/jampy/react-wakelock#readme",
   "main": "./dist/index.js",
   "dependencies": {
+    "prop-types": "^15.6.0",
+    "create-react-class": "^15.6.0"
   },
   "peerDependencies": {
   },

--- a/src/android.jsx
+++ b/src/android.jsx
@@ -1,4 +1,6 @@
-import React from 'react';
+import React from 'react'; 
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
 
 const media = {
   // taken from https://github.com/kud/blank-video
@@ -17,12 +19,12 @@ function addSourceToVideo(element, type, dataURI) {
 }
 
 
-let WakeLockAndroid = React.createClass({
+let WakeLockAndroid = createReactClass({
 
   displayName: "WakeLockAndroid",
 
   propTypes: {
-    preventSleep: React.PropTypes.bool
+    preventSleep: PropTypes.bool
   },
 
   getDefaultProps() {

--- a/src/ios.jsx
+++ b/src/ios.jsx
@@ -1,14 +1,16 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
 
 // method taken from https://github.com/richtr/NoSleep.js/blob/master/NoSleep.js
 // needs testing.
 
-let WakeLockIOS = React.createClass({
+let WakeLockIOS = createReactClass({
 
   displayName: "WakeLockIOS",
 
   propTypes: {
-    preventSleep: React.PropTypes.bool
+    preventSleep: PropTypes.bool
   },
 
   getDefaultProps() {


### PR DESCRIPTION
I needed the functionality of this package but came across a number of issues when using it in conjunction with React 16. This pull request adds in two dependancies `prop-types` and `create-react-class`, which have now been abstracted away from the core React library as of version 16, and updates instances where these removed functions are relied on in the code.

As mentioned, I needed to do this for `react-wakelock` to run with React 16 on my own personal project, so thought I'd submit as a pull request in case you wanted to incorporate these changes (I see there this one open issue, https://github.com/jampy/react-wakelock/issues/3, which this pull request would solve). 